### PR TITLE
Add Python scaffolding, dependency mapping, and CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,41 @@
+name: Python CI
+
+on:
+  push:
+    paths:
+      - "common_utils/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/python-ci.yml"
+  pull_request:
+    paths:
+      - "common_utils/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/python-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,automation,file_formats,networking,reporting]
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,17 @@ nb-configuration.xml
 ## OS X
 ##############################
 .DS_Store
+
+##############################
+## Python
+##############################
+.venv/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+*.egg-info/
+.eggs/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
-Created from template
+# Common Utils
 
-- Generic Template
+This repository contains the legacy Java automation toolkit alongside a nascent Python
+port.  The Python port mirrors the Java package layout so that modules can be translated
+incrementally without losing context or regression coverage.
+
+## Python scaffolding
+
+- `common_utils/` &ndash; placeholder Python packages that mirror `src/main/java`.
+- `tests/` &ndash; initial pytest suite validating that the scaffolding stays aligned with the
+  Java layout.
+- `pyproject.toml` &ndash; dependency mapping and tooling configuration for the Python stack.
+
+## Getting started
+
+1. Create a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install the project with the primary extras used by the automation toolkit:
+   ```bash
+   pip install -e .[dev,automation,file_formats,networking,reporting]
+   ```
+   The optional `datastores` extra pulls in `pyodbc`, which may require system-level ODBC
+   headers (e.g., `apt-get install unixodbc-dev` on Debian/Ubuntu) before installation.
+3. Run the quality gates:
+   ```bash
+   ruff check .
+   pytest
+   ```
+
+## Continuous integration
+
+A GitHub Actions workflow at `.github/workflows/python-ci.yml` installs the toolchain and
+runs `ruff` plus `pytest` on every push and pull request that touches the Python files or
+configuration.  This ensures that each newly ported module starts with regression
+coverage from the outset.

--- a/common_utils/AssertionsWithReport/__init__.py
+++ b/common_utils/AssertionsWithReport/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.AssertionsWithReport`."""

--- a/common_utils/Managers/__init__.py
+++ b/common_utils/Managers/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.Managers`."""

--- a/common_utils/Store/__init__.py
+++ b/common_utils/Store/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.Store`."""

--- a/common_utils/__init__.py
+++ b/common_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Top level Python package for ported common utilities."""

--- a/common_utils/apiUtils/__init__.py
+++ b/common_utils/apiUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.apiUtils`."""

--- a/common_utils/async/__init__.py
+++ b/common_utils/async/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.async`."""

--- a/common_utils/collectionUtils/__init__.py
+++ b/common_utils/collectionUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.collectionUtils`."""

--- a/common_utils/constantsUtils/__init__.py
+++ b/common_utils/constantsUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.constantsUtils`."""

--- a/common_utils/customAnnotations/__init__.py
+++ b/common_utils/customAnnotations/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.customAnnotations`."""

--- a/common_utils/dateTimeUtils/__init__.py
+++ b/common_utils/dateTimeUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.dateTimeUtils`."""

--- a/common_utils/dbUtils/__init__.py
+++ b/common_utils/dbUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.dbUtils`."""

--- a/common_utils/devToolsUtils/__init__.py
+++ b/common_utils/devToolsUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.devToolsUtils`."""

--- a/common_utils/dialogs/__init__.py
+++ b/common_utils/dialogs/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.dialogs`."""

--- a/common_utils/drivers/__init__.py
+++ b/common_utils/drivers/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.drivers`."""

--- a/common_utils/emailUtils/__init__.py
+++ b/common_utils/emailUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.emailUtils`."""

--- a/common_utils/emailUtils/mailSlurp/__init__.py
+++ b/common_utils/emailUtils/mailSlurp/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.emailUtils.mailSlurp`."""

--- a/common_utils/enumerations/__init__.py
+++ b/common_utils/enumerations/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.enumerations`."""

--- a/common_utils/extensions/__init__.py
+++ b/common_utils/extensions/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.extensions`."""

--- a/common_utils/fileUtils/__init__.py
+++ b/common_utils/fileUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.fileUtils`."""

--- a/common_utils/imageUtils/__init__.py
+++ b/common_utils/imageUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.imageUtils`."""

--- a/common_utils/kubernetesUtils/__init__.py
+++ b/common_utils/kubernetesUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.kubernetesUtils`."""

--- a/common_utils/listeners/__init__.py
+++ b/common_utils/listeners/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.listeners`."""

--- a/common_utils/metricsReport/__init__.py
+++ b/common_utils/metricsReport/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.metricsReport`."""

--- a/common_utils/miscellaneousUtils/__init__.py
+++ b/common_utils/miscellaneousUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.miscellaneousUtils`."""

--- a/common_utils/mobileUtils/__init__.py
+++ b/common_utils/mobileUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.mobileUtils`."""

--- a/common_utils/objectsUtils/__init__.py
+++ b/common_utils/objectsUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.objectsUtils`."""

--- a/common_utils/propertyUtils/__init__.py
+++ b/common_utils/propertyUtils/__init__.py
@@ -1,0 +1,6 @@
+"""Python port of the ``propertyUtils`` package."""
+
+from .property import Property
+from .property_utils import get_global_property, get_global_property_entity
+
+__all__ = ["Property", "get_global_property", "get_global_property_entity"]

--- a/common_utils/propertyUtils/property.py
+++ b/common_utils/propertyUtils/property.py
@@ -1,0 +1,109 @@
+"""Python implementation of the Java ``propertyUtils.Property`` helper."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Set
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Property:
+    """Utility class that loads and exposes ``.properties`` style files."""
+
+    _DEFAULT_GLOBAL_FILE = "zim.global.properties"
+
+    def __init__(self, path_to_property: Optional[str] = None) -> None:
+        self._properties: Dict[str, str] = {}
+        self._load_properties(path_to_property)
+
+    def _load_properties(self, path_to_property: Optional[str]) -> None:
+        candidate_paths = []
+        if path_to_property:
+            candidate_paths.append(Path(path_to_property))
+        candidate_paths.append(self._default_property_path())
+
+        for candidate in candidate_paths:
+            if candidate and candidate.exists():
+                try:
+                    self._properties = self._parse_property_file(candidate)
+                    return
+                except OSError as exc:
+                    _LOGGER.info("Could not initialize property file from %s", candidate)
+                    _LOGGER.info("%s", exc)
+        _LOGGER.info("Could not initialize property file")
+
+    def _default_property_path(self) -> Path:
+        project_root = Path(__file__).resolve().parents[2]
+        return project_root / "resources" / self._DEFAULT_GLOBAL_FILE
+
+    def _parse_property_file(self, path: Path) -> Dict[str, str]:
+        properties: Dict[str, str] = {}
+        with path.open("r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or line.startswith("!"):
+                    continue
+                if "=" in line:
+                    key, value = line.split("=", 1)
+                elif ":" in line:
+                    key, value = line.split(":", 1)
+                else:
+                    parts = line.split()
+                    if len(parts) < 2:
+                        continue
+                    key, value = parts[0], " ".join(parts[1:])
+                properties[key.strip()] = value.strip()
+        return properties
+
+    def get_property(self, key: str) -> Optional[str]:
+        return self._properties.get(key)
+
+    def set_property(self, key: str, value: str) -> None:
+        self._properties[key] = value
+
+    def remove_property(self, key: str) -> None:
+        self._properties.pop(key, None)
+
+    def get_int_property(self, key: str) -> Optional[int]:
+        value = self.get_property(key)
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError as exc:
+            _LOGGER.info(
+                "Value of key: %s is: %s can't parse it to int", key, value
+            )
+            _LOGGER.info("%s", exc)
+            return None
+
+    def get_double_property(self, key: str) -> Optional[float]:
+        value = self.get_property(key)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except ValueError as exc:
+            _LOGGER.info(
+                "Value of key: %s is: %s can't parse it to double", key, value
+            )
+            _LOGGER.info("%s", exc)
+            return None
+
+    def get_boolean_property(self, key: str) -> bool:
+        value = self.get_property(key)
+        return str(value).lower() == "true"
+
+    def get_all_keys_in_property_file(self) -> Set[str]:
+        return set(self._properties.keys())
+
+    def keys(self) -> Iterable[str]:
+        return self._properties.keys()
+
+    def items(self) -> Iterable[tuple[str, str]]:
+        return self._properties.items()
+
+    def values(self) -> Iterable[str]:
+        return self._properties.values()

--- a/common_utils/propertyUtils/property_utils.py
+++ b/common_utils/propertyUtils/property_utils.py
@@ -1,0 +1,22 @@
+"""Utility helpers mirroring the Java ``PropertyUtils`` class."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .property import Property
+
+
+def get_global_property_entity(path_to_property: Optional[str] = None) -> Property:
+    """Return a :class:`Property` instance for the global properties file."""
+
+    return Property(path_to_property)
+
+
+def get_global_property(key: str) -> Optional[str]:
+    """Fetch a value from the global properties file by ``key``."""
+
+    return Property().get_property(key)
+
+
+__all__ = ["get_global_property", "get_global_property_entity", "Property"]

--- a/common_utils/registryUtils/__init__.py
+++ b/common_utils/registryUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.registryUtils`."""

--- a/common_utils/reportUtils/__init__.py
+++ b/common_utils/reportUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.reportUtils`."""

--- a/common_utils/secretsManager/__init__.py
+++ b/common_utils/secretsManager/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.secretsManager`."""

--- a/common_utils/seleniumUtils/__init__.py
+++ b/common_utils/seleniumUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.seleniumUtils`."""

--- a/common_utils/seleniumUtils/customeElements/__init__.py
+++ b/common_utils/seleniumUtils/customeElements/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.seleniumUtils.customeElements`."""

--- a/common_utils/systemUtils/__init__.py
+++ b/common_utils/systemUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.systemUtils`."""

--- a/common_utils/tableUtils/__init__.py
+++ b/common_utils/tableUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.tableUtils`."""

--- a/common_utils/verificationsUtils/__init__.py
+++ b/common_utils/verificationsUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.verificationsUtils`."""

--- a/common_utils/waitUtils/__init__.py
+++ b/common_utils/waitUtils/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.waitUtils`."""

--- a/common_utils/webUtills/__init__.py
+++ b/common_utils/webUtills/__init__.py
@@ -1,0 +1,1 @@
+"""Python port placeholder for `common_utils.webUtills`."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,100 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "common-utils"
+version = "0.1.0"
+description = "Python scaffolding for the Common Utils automation toolkit."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "QA Automation" }
+]
+keywords = ["automation", "testing", "utilities"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Operating System :: OS Independent"
+]
+dependencies = []
+
+[project.optional-dependencies]
+# Selenium/Appium automation surface mapped from the Java toolchain
+automation = [
+    "selenium>=4.18.1,<5.0",
+    "appium-python-client>=4.0.0",
+    "mss>=9.0.1",
+    "pillow>=10.2.0",
+    "PyHamcrest>=2.1.0"
+]
+
+# HTTP clients, authentication, and mail integrations
+networking = [
+    "requests>=2.31.0",
+    "httpx>=0.27.0",
+    "PyJWT>=2.8.0",
+    "mailslurp-client>=15.19.22",
+    "msal>=1.28.0",
+    "adal>=1.2.7"
+]
+
+# Database connectivity and connection pooling equivalents
+# HikariCP, Spring JDBC, SQLite, and MSSQL driver coverage
+# Note: installing pyodbc may require system ODBC headers (unixODBC) on Linux/macOS.
+datastores = [
+    "sqlalchemy>=2.0.29",
+    "pyodbc>=5.1.0"
+]
+
+# File format tooling: Excel/CSV, PDF, JSON, and charting/reporting helpers
+file_formats = [
+    "pandas>=2.2.1",
+    "openpyxl>=3.1.2",
+    "pypdf>=4.1.0",
+    "orjson>=3.10.0",
+    "matplotlib>=3.8.3"
+]
+
+# Reporting harness analogous to ExtentReports / HP LFT stack
+reporting = [
+    "allure-pytest>=2.13.2"
+]
+
+# Development-time quality gates and test stack
+dev = [
+    "pytest>=8.1.1",
+    "pytest-cov>=5.0.0",
+    "ruff>=0.3.5",
+    "mypy>=1.9.0"
+]
+
+[project.urls]
+"Source" = "https://github.com/example/common_utils"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["common_utils*"]
+
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "--strict-markers --disable-warnings --maxfail=1"
+testpaths = ["tests"]
+pythonpath = ["."]
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+src = ["common_utils", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B"]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+

--- a/tests/propertyUtils/test_property.py
+++ b/tests/propertyUtils/test_property.py
@@ -1,0 +1,58 @@
+"""Tests for the Python ``Property`` implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from common_utils.propertyUtils import (
+    Property,
+    get_global_property,
+    get_global_property_entity,
+)
+
+
+def test_default_properties_file_is_loaded() -> None:
+    prop = Property()
+
+    assert prop.get_property("timeout") == "30"
+    assert prop.get_int_property("timeout") == 30
+
+
+def test_custom_property_file_overrides_default(tmp_path: Path) -> None:
+    custom_file = tmp_path / "custom.properties"
+    custom_file.write_text("answer=42\nflag=true\nratio=3.5\n", encoding="utf-8")
+
+    prop = Property(str(custom_file))
+
+    assert prop.get_property("answer") == "42"
+    assert prop.get_int_property("answer") == 42
+    assert prop.get_double_property("ratio") == pytest.approx(3.5)
+    assert prop.get_boolean_property("flag") is True
+    assert prop.get_all_keys_in_property_file() == {"answer", "flag", "ratio"}
+
+
+def test_missing_key_returns_none() -> None:
+    prop = Property()
+
+    assert prop.get_property("missing") is None
+    assert prop.get_int_property("missing") is None
+    assert prop.get_double_property("missing") is None
+    assert prop.get_boolean_property("missing") is False
+
+
+def test_invalid_numeric_values_return_none(tmp_path: Path) -> None:
+    custom_file = tmp_path / "invalid.properties"
+    custom_file.write_text("value=not-a-number\n", encoding="utf-8")
+
+    prop = Property(str(custom_file))
+
+    assert prop.get_int_property("value") is None
+    assert prop.get_double_property("value") is None
+
+
+def test_global_property_helpers() -> None:
+    prop = get_global_property_entity()
+
+    assert isinstance(prop, Property)
+    assert get_global_property("timeout_page_load") == "120"

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -1,0 +1,52 @@
+"""Regression scaffolding for the Python port of the common utilities toolkit."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+JAVA_ROOT = Path("src/main/java")
+PYTHON_ROOT = Path("common_utils")
+
+
+def _java_package_paths() -> list[Path]:
+    """Collect all Java package directories relative to the Java source root."""
+    packages: list[Path] = []
+    for candidate in JAVA_ROOT.rglob("*"):
+        if candidate.is_dir():
+            relative = candidate.relative_to(JAVA_ROOT)
+            if relative.parts:
+                packages.append(relative)
+    return packages
+
+
+def test_python_package_structure_matches_java() -> None:
+    """Each Java package should already have a Python placeholder."""
+    missing: list[str] = []
+    for relative in _java_package_paths():
+        python_dir = PYTHON_ROOT / relative
+        if not python_dir.is_dir():
+            missing.append(str(relative))
+            continue
+        if not (python_dir / "__init__.py").exists():
+            missing.append(f"{relative} (missing __init__.py)")
+    assert not missing, (
+        "The Python scaffolding is incomplete for: " + ", ".join(sorted(missing))
+    )
+
+
+@pytest.mark.parametrize(
+    "package_name",
+    [
+        "common_utils.collectionUtils",
+        "common_utils.propertyUtils",
+        "common_utils.reportUtils",
+        "common_utils.seleniumUtils",
+    ],
+)
+def test_high_priority_packages_are_importable(package_name: str) -> None:
+    """Basic smoke test confirming the high-priority packages can be imported."""
+    module = importlib.import_module(package_name)
+    assert module.__doc__, f"{package_name} is missing a module docstring"


### PR DESCRIPTION
## Summary
- scaffolded a `common_utils` Python package that mirrors the existing Java layout so that future ports can land in place
- added a `pyproject.toml` with optional dependency groups plus README/gitignore updates covering the Python workflow
- introduced a pytest regression scaffold and a GitHub Actions workflow that runs linting and tests on relevant changes
- ported the Java `propertyUtils` package to working Python equivalents with helpers for typed access to global properties and regression tests

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca7e45afa4832daa38a37daad2f508